### PR TITLE
Awesome Grunt Workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+bower_components
+node_modules
+
+_build/lib
+_build/temp

--- a/_build/README.md
+++ b/_build/README.md
@@ -1,0 +1,72 @@
+What you need
+--------------------------------------
+
+In order to build redactor-js-font-awesome front end assets, you need to have Node.js/npm latest and git 1.7 or later.
+(Earlier versions might work OK, but are not tested.)
+
+For Windows you have to download and install [git](http://git-scm.com/downloads) and [Node.js](http://nodejs.org/download/).
+
+Mac OS users should install [Homebrew](http://mxcl.github.com/homebrew/). Once Homebrew is installed, run `brew install git` to install git,
+and `brew install node` to install Node.js.
+
+Linux/BSD users should use their appropriate package managers to install git and Node.js, or build from source
+if you swing that way. Easy-peasy.
+
+
+Installing Grunt & Grunt Packages
+----------------------------
+
+First, clone a copy of this git repo by running:
+
+```bash
+git clone -b grunt git@github.com:karen2k/redactor-js-font-awesome.git
+```
+
+Install the [grunt-cli](http://gruntjs.com/getting-started#installing-the-cli) package if you haven't before. These should be done as global installs:
+
+```bash
+npm install -g grunt-cli
+```
+
+Make sure you have `grunt` installed by testing:
+
+```bash
+grunt --version
+```
+
+Enter the _build directory and install the Node and Bower dependencies, this time *without* specifying a global(-g) install:
+
+```bash
+cd redactor-js-font-awesome/_build/
+npm install
+```
+_Note: `npm update` updates dependencies and should be run whenever you pull from git._
+
+Optionally enable Growl notifications install [terminal-notifier](https://github.com/alextucker/grunt-growl#getting-started) with RubyGems:
+```bash
+gem install terminal-notifier
+```
+_Note: Depending on your Ruby setup you may need to use `sudo gem install terminal-notifier`._
+
+Grunt Commands
+----------------------------
+
+__List__  
+Checks out the latest font-awesome using bower and writes a temporary file containing a JavaScript array of icon classes.
+
+```bash
+grunt list
+```
+
+__FA__  
+Updates `redactor-awesome.js` with the latest font-awesome icons and cleans up temporary files.
+
+```bash
+grunt fa
+```
+
+Always run `grunt list` before `grunt fa` like so:
+
+```bash
+grunt list && grunt fa
+````

--- a/_build/bower.json
+++ b/_build/bower.json
@@ -1,0 +1,30 @@
+{
+  "name": "redactor-js-font-awesome",
+  "version": "1.0.0",
+  "homepage": "https://github.com/jpdevries/redactor-js-font-awesome",
+  "description": "Awesome icons font for awesome Redactor.js",
+  "authors": [
+    "JP DeVries <johnpaul.devries@gmail.com>"
+  ],
+  "main": "index.html",
+  "keywords": [
+    "redactor",
+    "font-awesome"
+  ],
+  "license": "MIT",
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "bower_components",
+    "test",
+    "tests"
+  ],
+  "dependencies": {
+    "font-awesome": "^4.5.0"
+  },
+  "exportsOverride": {
+    "font-awesome": {
+      "scss": ["scss"]
+    }
+  }
+}

--- a/_build/gruntfile.js
+++ b/_build/gruntfile.js
@@ -1,0 +1,63 @@
+'use strict';
+
+module.exports = function(grunt) {
+    var initConfig = {
+        pkg: grunt.file.readJSON('package.json'),
+        dirs:{
+            'awesome':'../awesome/'
+        },
+		bower: {
+			install: {
+				options: {
+					targetDir: './lib',
+					layout:'byComponent'
+				}
+			}
+		},
+		'font-awesome-list':{
+			list:{
+				options:{
+					src:'./lib/font-awesome/scss/_icons.scss',
+                    dest:'./temp/font-awesome-icons.txt'
+				}
+			}
+		},
+        'string-replace':{},
+		clean: { /* take out the trash */
+			postbuild: ['./temp','./lib']
+		},
+        growl:{
+			fa: {
+				title: "grunt",
+				message: "Font-Awesome updated."
+			},
+        }
+	};
+    
+    if(grunt.file.isFile('./temp/font-awesome-icons.txt')) {
+        initConfig['string-replace'] = {
+            fa: {
+                files: [
+                    {src:'<%= dirs.awesome %>redactor-awesome.js',dest:'<%= dirs.awesome %>redactor-awesome.js'}
+                ],
+                options: {
+                    replacements:[{
+						pattern:/(icons:)(.*)/gi,
+						replacement:'icons: ' + grunt.file.read('./temp/font-awesome-icons.txt')
+                    }]
+                }
+            }
+        };
+    }
+    
+	grunt.initConfig(initConfig);
+	
+    grunt.loadNpmTasks('grunt-bower-task');
+    grunt.loadNpmTasks('grunt-font-awesome-list');
+    grunt.loadNpmTasks('grunt-string-replace');
+    grunt.loadNpmTasks('grunt-contrib-clean');
+    grunt.loadNpmTasks('grunt-growl');
+    
+    grunt.registerTask('list',['bower','font-awesome-list']); // always run list before fa ex: grunt list && grunt fa
+    grunt.registerTask('fa',['string-replace','growl:fa','clean:postbuild']);
+};

--- a/_build/package.json
+++ b/_build/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "redactor-js-font-awesome",
+  "version": "1.0.0",
+  "description": "Awesome icons font for awesome Redactor.js",
+  "main": "gruntfile.js",
+  "dependencies": {
+    "fontawesome-list": "^0.0.0"
+  },
+  "devDependencies": {
+    "grunt": "^0.4.5",
+    "grunt-bower-task": "^0.4.0",
+    "grunt-contrib-clean": "^0.7.0",
+    "grunt-font-awesome-list": "^1.0.0",
+    "grunt-growl": "^0.1.5",
+    "grunt-string-replace": "^1.2.0"
+  },
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/jpdevries/redactor-js-font-awesome.git"
+  },
+  "author": "",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/jpdevries/redactor-js-font-awesome/issues"
+  },
+  "homepage": "https://github.com/jpdevries/redactor-js-font-awesome#readme"
+}


### PR DESCRIPTION
automates updating to the latest version of font-awesome by running

``` bash
grunt list && grunt fa
```

I didn't commit the `redactor-awesome.js` changes because I figured I'd let you test out the workflow ;)

Please

``` bash
cd redactor-js-font-awesome/_build
npm install
grunt list && grunt fa
```

If you aren't already set up with Node.js and Grunt please see `_build/README.md`.
